### PR TITLE
feature: gestor indica duração das reservas

### DIFF
--- a/src/main/java/br/com/nat/quadralivre/domain/quadra/Quadra.java
+++ b/src/main/java/br/com/nat/quadralivre/domain/quadra/Quadra.java
@@ -26,6 +26,11 @@ public class Quadra {
     @Column(nullable = false)
     private Endereco endereco;
 
+    @Column(nullable = false)
+    private Integer minutosReserva;
+    @Column(nullable = false)
+    private Integer minutosIntervalo;
+
     @ManyToOne
     private Usuario gestor;
 
@@ -47,6 +52,14 @@ public class Quadra {
 
         if (quadraAtualizacao.endereco() != null){
             this.endereco.atualizar(quadraAtualizacao.endereco());
+        }
+
+        if (quadraAtualizacao.minutosReserva() != null){
+            this.minutosReserva = quadraAtualizacao.minutosReserva();
+        }
+
+        if (quadraAtualizacao.minutosIntervalo() != null){
+            this.minutosIntervalo = quadraAtualizacao.minutosIntervalo();
         }
     }
 }

--- a/src/main/java/br/com/nat/quadralivre/domain/quadra/QuadraAtualizacao.java
+++ b/src/main/java/br/com/nat/quadralivre/domain/quadra/QuadraAtualizacao.java
@@ -1,8 +1,9 @@
 package br.com.nat.quadralivre.domain.quadra;
 
 import br.com.nat.quadralivre.domain.quadra.endereco.EnderecoRegistro;
-import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PositiveOrZero;
 import jakarta.validation.constraints.Size;
 
 public record QuadraAtualizacao (
@@ -10,6 +11,10 @@ public record QuadraAtualizacao (
         Long id,
         @Size(min = 4, message = "O nome deve ter pelo menos 4 caracteres.")
         String nome,
-        EnderecoRegistro endereco
+        EnderecoRegistro endereco,
+        @Min(60)
+        Integer minutosReserva,
+        @PositiveOrZero
+        Integer minutosIntervalo
 ){
 }

--- a/src/main/java/br/com/nat/quadralivre/domain/quadra/QuadraDadosDetalhados.java
+++ b/src/main/java/br/com/nat/quadralivre/domain/quadra/QuadraDadosDetalhados.java
@@ -7,9 +7,11 @@ public record QuadraDadosDetalhados(
         Long id,
         String nome,
         Endereco endereco,
+        Integer minutosReserva,
+        Integer minutosIntervalo,
         UsuarioDadosAberto gestor
 ) {
     public QuadraDadosDetalhados(Quadra quadra){
-        this(quadra.getId(), quadra.getNome(), quadra.getEndereco(), new UsuarioDadosAberto(quadra.getGestor()));
+        this(quadra.getId(), quadra.getNome(), quadra.getEndereco(), quadra.getMinutosReserva(), quadra.getMinutosIntervalo(), new UsuarioDadosAberto(quadra.getGestor()));
     }
 }

--- a/src/main/java/br/com/nat/quadralivre/domain/quadra/QuadraRegistro.java
+++ b/src/main/java/br/com/nat/quadralivre/domain/quadra/QuadraRegistro.java
@@ -15,6 +15,7 @@ public record QuadraRegistro(
         Integer minutosReserva,
         @NotNull
         @PositiveOrZero
+        @Max(720)
         Integer minutosIntervalo
 ) {
 }

--- a/src/main/java/br/com/nat/quadralivre/domain/quadra/QuadraRegistro.java
+++ b/src/main/java/br/com/nat/quadralivre/domain/quadra/QuadraRegistro.java
@@ -1,13 +1,20 @@
 package br.com.nat.quadralivre.domain.quadra;
 
 import br.com.nat.quadralivre.domain.quadra.endereco.Endereco;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.*;
 
 public record QuadraRegistro(
         @NotBlank
         String nome,
         @NotNull
-        Endereco endereco
+        Endereco endereco,
+        @NotNull
+        // min: 1 hora max: 12 horas
+        @Min(60)
+        @Max(720)
+        Integer minutosReserva,
+        @NotNull
+        @PositiveOrZero
+        Integer minutosIntervalo
 ) {
 }

--- a/src/main/java/br/com/nat/quadralivre/infra/security/SecurityFilter.java
+++ b/src/main/java/br/com/nat/quadralivre/infra/security/SecurityFilter.java
@@ -27,6 +27,11 @@ public class SecurityFilter extends OncePerRequestFilter {
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
         var tokenJWT = this.recuperarToken(request);
 
+        if (tokenJWT == null){
+            filterChain.doFilter(request, response);
+            return;
+        }
+
         try{
             var subject  = this.tokenService.getSubject(tokenJWT);
             var usuario = this.usuarioRepository.findByLogin(subject);

--- a/src/main/resources/db/migration/V6__alter-table-quadra-add-column-minutos-reserva-e-intervalo.sql
+++ b/src/main/resources/db/migration/V6__alter-table-quadra-add-column-minutos-reserva-e-intervalo.sql
@@ -1,0 +1,7 @@
+ALTER TABLE quadras ADD COLUMN minutosReserva int;
+ALTER TABLE quadras ADD COLUMN minutosIntervalo int;
+
+UPDATE quadras SET minutosReserva = 60, minutosIntervalo = 10;
+
+ALTER TABLE quadras ALTER COLUMN minutosReserva SET NOT NULL;
+ALTER TABLE quadras ALTER COLUMN minutosIntervalo SET NOT NULL;

--- a/src/main/resources/db/migration/V7__alter-table-quadra-update-column-minutos-reserva-e-intervalo-name.sql
+++ b/src/main/resources/db/migration/V7__alter-table-quadra-update-column-minutos-reserva-e-intervalo-name.sql
@@ -1,0 +1,2 @@
+ALTER TABLE quadras RENAME COLUMN minutosreserva TO minutos_reserva;
+ALTER TABLE quadras RENAME COLUMN minutosintervalo TO minutos_intervalo;


### PR DESCRIPTION
### descrição:

esse pull request implementa a possibilidade de o `Gestor` definir a **duração das reservas e o intervalo entre elas**, trazendo mais flexibilidade para API.

antes, esses valores eram fixos no código. Agora, ao criar uma nova `Quadra`, o `Gestor` deve informar os tempos (**em minutos**) de duração da reserva e do intervalo entre reservas.

exemplo: 
```json
"minutosReserva": 120,
"minutosIntervalo": 10,
```